### PR TITLE
Populate input element "name" attributes, with optional prefix

### DIFF
--- a/builder.js
+++ b/builder.js
@@ -11,7 +11,7 @@ function ViewModel(data) {
 	this.countries = ko.observableArray(componentData.countries);
 	this.instanceName = data.instanceName;
 	this.address = getObservableAddress(data.address, this.states, this.countries, !!data.validate);
-
+	this.namePrefix = data.namePrefix || "";
 }
 
 function initDisplayOptions(data) {

--- a/demos/index.html
+++ b/demos/index.html
@@ -1,16 +1,18 @@
 ﻿<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
+
 <head>
 	<title>Address Builder Example</title>
 
 	<link rel="stylesheet" href="./bootstrap/dist/css/bootstrap.css">
 
 </head>
+
 <body>
 	<div class="container">
 		<h1>Address Builder Example</h1>
 		<h5>(start changing me to update the viewer)</h5>
-		<div class="well" data-bind="addressBuilder: address">
+		<div class="well" data-bind="addressBuilder: address" data-name-prefix="prefix_">
 		</div>
 	</div>
 
@@ -25,7 +27,8 @@
 		<pre class="well" data-bind="text: address2.formatted">
 		</pre>
 	</div>
-<script src="./jquery/dist/jquery.js" type="text/javascript"></script>	
-<script src="./build.js" type="text/javascript"></script>
+	<script src="./jquery/dist/jquery.js" type="text/javascript"></script>
+	<script src="./build.js" type="text/javascript"></script>
 </body>
+
 </html>

--- a/knockout.address.js
+++ b/knockout.address.js
@@ -12,14 +12,15 @@ require("knockout-template?name=address-viewer!html!./templates/address-viewer.h
 ko.punches.enableAll();
 
 ko.bindingHandlers.addressBuilder = {
-	init: function (element) {
+	init: function(element) {
 		element.instanceName = _uniqueId("addy-build--");
 		return { controlsDescendantBindings: true };
 	},
-	update: function (element, valueAccessor, allBindings) {
+	update: function(element, valueAccessor, allBindings) {
 		var data = {};
 		data.address = valueAccessor();
 		data.instanceName = element.instanceName;
+		data.namePrefix = element.dataset.namePrefix;
 		data.displayOptions = ko.unwrap(allBindings.get("displayOptions"));
 		data.validate = ko.unwrap(allBindings.get("validate"));
 		var model = new Builder(data);
@@ -28,11 +29,11 @@ ko.bindingHandlers.addressBuilder = {
 };
 
 ko.bindingHandlers.addressViewer = {
-	init: function (element) {
+	init: function(element) {
 		element.instanceName = _uniqueId("addy-view--");
 		return { controlsDescendantBindings: true };
 	},
-	update: function (element, valueAccessor, allBindings) {
+	update: function(element, valueAccessor, allBindings) {
 		var data = {};
 		data.address = valueAccessor();
 		data.instanceName = element.instanceName;
@@ -43,18 +44,18 @@ ko.bindingHandlers.addressViewer = {
 	}
 };
 
-ko.extenders.address = function (target, defaultValue) {
+ko.extenders.address = function(target, defaultValue) {
 	var validate = (defaultValue && defaultValue.validate === true) || false;
 	var result = ko.computed({
-		read: function () {
+		read: function() {
 			return ko.unwrap(target) instanceof Address ? target : target(new Address(ko.unwrap(target), null, null, validate));
 		},
-		write: function (value) {
+		write: function(value) {
 			target(new Address(value, null, null, validate));
 		}
 	});
 
-	result.formatted = ko.computed(function () {
+	result.formatted = ko.computed(function() {
 		return !!target() && target().formatted ? target().formatted() : "";
 	});
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knockout.address",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "address bindings and extension for observable address objects",
   "main": "knockout.address.js",
   "scripts": {

--- a/templates/address-builder.html
+++ b/templates/address-builder.html
@@ -4,21 +4,24 @@
 		<div class="form-group addy-build__line1__container">
 			<label class="col-sm-2 control-label" for="{{$parent.instanceName}}__line-1">Street</label>
 			<div class="col-sm-10">
-				<input data-bind="css: $parent.displayOptions.inputSize, valueUpdate: 'keyup', value: address1" maxlength="50" type="text" placeholder="Address Line 1" class="form-control" id="{{$parent.instanceName}}__line-1">
+				<input data-bind="css: $parent.displayOptions.inputSize, valueUpdate: 'keyup', value: address1" maxlength="50" type="text"
+				 placeholder="Address Line 1" class="form-control" id="{{$parent.instanceName}}__line-1" name="{{$parent.namePrefix}}line1">
 			</div>
 		</div>
 
 		<div class="form-group addy-build__line2__container">
 			<label class="col-sm-2 control-label" for="{{$parent.instanceName}}__line-2">Apt/Unit</label>
 			<div class="col-sm-10">
-				<input data-bind="css: $parent.displayOptions.inputSize, valueUpdate: 'keyup', value: address2" type="text" maxlength="50" placeholder="Address Line 2" class="form-control" id="{{$parent.instanceName}}__line-2">
+				<input data-bind="css: $parent.displayOptions.inputSize, valueUpdate: 'keyup', value: address2" type="text" maxlength="50"
+				 placeholder="Address Line 2" class="form-control" id="{{$parent.instanceName}}__line-2" name="{{$parent.namePrefix}}line2">
 			</div>
 		</div>
 
 		<div class="form-group addy-build__city__container">
 			<label class="col-sm-2 control-label" for="{{$parent.instanceName}}__city">City</label>
 			<div class="col-sm-10">
-				<input data-bind="css: $parent.displayOptions.inputSize, valueUpdate: 'keyup', value: city" type="text" maxlength="50" placeholder="City" class="form-control" id="{{$parent.instanceName}}__city">
+				<input data-bind="css: $parent.displayOptions.inputSize, valueUpdate: 'keyup', value: city" type="text" maxlength="50" placeholder="City"
+				 class="form-control" id="{{$parent.instanceName}}__city" name="{{$parent.namePrefix}}city">
 			</div>
 		</div>
 
@@ -26,15 +29,16 @@
 			<label class="col-sm-2 control-label" for="{{$parent.instanceName}}__state">State</label>
 			<div class="col-sm-4" data-bind="with:$parent">
 				<select data-bind="css: displayOptions.inputSize, options: states,
-                       optionsText: 'name',
-					   optionsValue: 'abbreviation',
-                       value: address().state,
-                       optionsCaption: 'Choose...'" class="form-control" id="{{instanceName}}__state"></select>
+					optionsText: 'name',
+					optionsValue: 'abbreviation',
+					value: address().state,
+					optionsCaption: 'Choose...'" class="form-control" id="{{instanceName}}__state" name="{{namePrefix}}state"></select>
 			</div>
 
 			<label class="col-sm-2 control-label" for="{{$parent.instanceName}}__postal-code">ZIP</label>
 			<div class="col-sm-4">
-				<input type="text" maxlength="10" data-bind="css: $parent.displayOptions.inputSize, value: postalCode, valueUpdate: 'keyup'" placeholder="Zip Code" class="form-control" id="{{$parent.instanceName}}__postal-code">
+				<input type="text" maxlength="10" data-bind="css: $parent.displayOptions.inputSize, value: postalCode, valueUpdate: 'keyup'"
+				 placeholder="Zip Code" class="form-control" id="{{$parent.instanceName}}__postal-code" name="{{$parent.namePrefix}}postalCode">
 			</div>
 		</div>
 
@@ -43,10 +47,10 @@
 			<label class="col-sm-2 control-label" for="{{$parent.instanceName}}__country">Country</label>
 			<div class="col-sm-10" data-bind="with:$parent">
 				<select data-bind="css: displayOptions.inputSize, options: countries,
-                       optionsText: 'name',
-					   optionsValue: 'code',
-                       value: address().country,
-                       optionsCaption: 'Choose...'" class="form-control" id="{{instanceName}}__country"></select>
+					optionsText: 'name',
+					optionsValue: 'code',
+					value: address().country,
+					optionsCaption: 'Choose...'" class="form-control" id="{{instanceName}}__country" name="{{namePrefix}}country"></select>
 			</div>
 		</div>
 		{{/if}}

--- a/test/builder.js
+++ b/test/builder.js
@@ -2,7 +2,7 @@
 var ViewModel = require("../builder");
 var expect = require("chai").expect;
 
-describe("Address Builder ViewModel", function () {
+describe("Address Builder ViewModel", function() {
 
 
 	var data = {
@@ -17,12 +17,12 @@ describe("Address Builder ViewModel", function () {
 
 	var model;
 
-	describe("When creating a new model with address data", function () {
-		beforeEach(function () {
+	describe("When creating a new model with address data", function() {
+		beforeEach(function() {
 			model = new ViewModel({ address: data, instanceName: data.instanceName });
 		}, this);
 
-		it("should be populated with an address of observable values", function () {
+		it("should be populated with an address of observable values", function() {
 			expect(model.address().address1()).to.equal("950 Gravier");
 			expect(model.address().address2()).to.equal("1700");
 			expect(model.address().city()).to.equal("New Orleans");
@@ -31,12 +31,12 @@ describe("Address Builder ViewModel", function () {
 			expect(model.address().country()).to.equal("US");
 		}, this);
 
-		it("should have countries", function () {
-			expect(model.countries().length > 0).to.equal(true);
+		it("should have countries", function() {
+			expect(model.countries().length).to.be.greaterThan(0);
 		});
 
-		it("should have states", function () {
-			expect(model.states().length > 0).to.equal(true);
+		it("should have states", function() {
+			expect(model.states().length).to.be.greaterThan(0);
 		});
 
 	});


### PR DESCRIPTION
- Add `name` attributes so that the elements can be submitted in a `<FORM>`  without having to externally wire up JS to set the element `name`s.